### PR TITLE
Prefer to use "instance_double" instead of "double"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A note on the language:
 
 * Use `not_to` instead of `to_not` in RSpec expectations.
 * Prefer to follow the [betterspecs.org](http://betterspecs.org/) rules.
+* Prefer to use `instance_double` instead of `double` with RSpec.
 * Avoid using associations in `FactoryGirl`, use them in `trait`.
 * Don't test private methods.
 


### PR DESCRIPTION
> In addition, when it receives messages, it verifies that the provided arguments are supported by the method signature, both in terms of arity and allowed or required keyword arguments, if any.

https://relishapp.com/rspec/rspec-mocks/v/3-2/docs/verifying-doubles/using-an-instance-double

/cc @linchus @Bugagazavr 