### PR TITLE
Use full path for constant resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ A note on the language:
 * <a name="ruby-error-class"></a>
   Use `Class.new(StandardError)` instead of inheritance to declare a single-line error class.
   <sup>[[link](#ruby-error-class)]</sup>
+* <a name="ruby-const-path"></a>
+  Use full path for constant resolution. [Example](./examples/ruby-const-path.rb).
+  <sup>[[link](#ruby-const-path)]</sup>
 * <a name="ruby-di"></a>
   Prefer to use Dependency Injection pattern instead of specifying a hardcoded behavior for the environment.
   <sup>[[link](#ruby-di)]</sup>

--- a/examples/ruby-const-path.rb
+++ b/examples/ruby-const-path.rb
@@ -1,0 +1,16 @@
+module MyModule
+  class MyClass
+  end
+end
+
+# bad
+module MyModule
+  class Foo < MyClass
+  end
+end
+
+# good
+module MyModule
+  class Foo < MyModule::MyClass
+  end
+end


### PR DESCRIPTION
In my opinion, it's always better to use full path for constant resolution. It will allow to fail-fast on boot time, prevent from loading incorrect constants and failing in runtime.

![](https://media.giphy.com/media/gbM6ghFyZKFHi/giphy.gif)

Here is what recently happened in one of our projects. Assume that we have the following files:

```ruby
# my_class.rb
class MyClass
end

# my_module/my_class.rb
module MyModule
  class MyClass
  end
end
```

And we have another file:
```ruby
# my_module/foo.rb
module MyModule
  class Foo < MyClass
  end
end
```

Somebody made some changes. And file `my_module/my_class.rb` wasn't loaded.  I think you can guess what happened next :)

The application started correctly, but failed in runtime as class `Foo` relies on the `MyModule::MyClass` implementation, not `MyClass`.